### PR TITLE
fix(scripts): fix Linux script

### DIFF
--- a/scripts/brun.sh
+++ b/scripts/brun.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/bash
+#!/usr/bin/sh
 # MIT License
 # 
 # Copyright (c) 2021 Fract


### PR DESCRIPTION
<!-- Description about of your PR -->
### Description
brun.sh saved in DOS format. In DOS format, the newline is `\r\n`. The shell interprets the script with `\n` characters when interpreting it. So the path we want `/bin/sh` to be becomes `/bin/sh\r`.

<!-- Please write if there are any important things we need to know about this PR -->
### Warns
N/A

<!--
  Please replace what you want to mark with [x]
  * - Must
--->
### Checks
- [X] I accept that the contributions be published under this [license](https://github.com/fract-lang/fract/blob/main/LICENSE)
- [X] Tested code
- [ ] Added documentations for code.
